### PR TITLE
Executor added to block key

### DIFF
--- a/runner/exec.go
+++ b/runner/exec.go
@@ -36,7 +36,7 @@ func exec(task executor.Task, blocker blocker, logger *logrus.Logger) (execResul
 		return execResultSuccessWithoutBlock, nil
 	}
 
-	success, err := blocker.BlockInProgress(task.Fingerprint())
+	success, err := blocker.BlockInProgress(task.ExecutorName(), task.Fingerprint())
 	if err != nil {
 		return execResultBlockError, err
 	}
@@ -47,11 +47,11 @@ func exec(task executor.Task, blocker blocker, logger *logrus.Logger) (execResul
 
 	err = task.Exec(logger)
 	if err != nil {
-		blocker.Unblock(task.Fingerprint())
+		blocker.Unblock(task.ExecutorName(), task.Fingerprint())
 		return execResultExecError, err
 	}
 
-	err = blocker.BlockForTTL(task.Fingerprint(), task.BlockTTL())
+	err = blocker.BlockForTTL(task.ExecutorName(), task.Fingerprint(), task.BlockTTL())
 	if err != nil {
 		return execResultCanNotBlock, err
 	}

--- a/runner/exec_test.go
+++ b/runner/exec_test.go
@@ -35,9 +35,10 @@ func Test_exec(t *testing.T) {
 			expectFunc: func(t *executor.MockTask, b *Mockblocker, l *logrus.Logger) {
 				t.EXPECT().BlockTTL().Return(10 * time.Minute).Times(2)
 				t.EXPECT().Fingerprint().Return("testfp1").Times(2)
-				b.EXPECT().BlockInProgress("testfp1").Return(true, nil)
+				t.EXPECT().ExecutorName().Return("shell").Times(2)
+				b.EXPECT().BlockInProgress("shell", "testfp1").Return(true, nil)
 				t.EXPECT().Exec(l).Return(nil)
-				b.EXPECT().BlockForTTL("testfp1", 10*time.Minute).Return(nil)
+				b.EXPECT().BlockForTTL("shell", "testfp1", 10*time.Minute).Return(nil)
 			},
 			expectedResult: execResultSuccess,
 			expectedErr:    nil,
@@ -48,7 +49,8 @@ func Test_exec(t *testing.T) {
 			expectFunc: func(t *executor.MockTask, b *Mockblocker, l *logrus.Logger) {
 				t.EXPECT().BlockTTL().Return(10 * time.Minute)
 				t.EXPECT().Fingerprint().Return("testfp1")
-				b.EXPECT().BlockInProgress("testfp1").Return(false, nil)
+				t.EXPECT().ExecutorName().Return("shell")
+				b.EXPECT().BlockInProgress("shell", "testfp1").Return(false, nil)
 			},
 			expectedResult: execResultInBlock,
 			expectedErr:    nil,
@@ -59,7 +61,8 @@ func Test_exec(t *testing.T) {
 			expectFunc: func(t *executor.MockTask, b *Mockblocker, l *logrus.Logger) {
 				t.EXPECT().BlockTTL().Return(10 * time.Minute)
 				t.EXPECT().Fingerprint().Return("testfp1")
-				b.EXPECT().BlockInProgress("testfp1").Return(false, errors.New("block error"))
+				t.EXPECT().ExecutorName().Return("shell")
+				b.EXPECT().BlockInProgress("shell", "testfp1").Return(false, errors.New("block error"))
 			},
 			expectedResult: execResultBlockError,
 			expectedErr:    errors.New("block error"),
@@ -70,9 +73,10 @@ func Test_exec(t *testing.T) {
 			expectFunc: func(t *executor.MockTask, b *Mockblocker, l *logrus.Logger) {
 				t.EXPECT().BlockTTL().Return(10 * time.Minute)
 				t.EXPECT().Fingerprint().Return("testfp1").Times(2)
-				b.EXPECT().BlockInProgress("testfp1").Return(true, nil)
+				t.EXPECT().ExecutorName().Return("shell").Times(2)
+				b.EXPECT().BlockInProgress("shell", "testfp1").Return(true, nil)
 				t.EXPECT().Exec(l).Return(errors.New("exec error"))
-				b.EXPECT().Unblock("testfp1")
+				b.EXPECT().Unblock("shell", "testfp1")
 			},
 			expectedResult: execResultExecError,
 			expectedErr:    errors.New("exec error"),
@@ -103,9 +107,10 @@ func Test_exec(t *testing.T) {
 			expectFunc: func(t *executor.MockTask, b *Mockblocker, l *logrus.Logger) {
 				t.EXPECT().BlockTTL().Return(10 * time.Minute).Times(2)
 				t.EXPECT().Fingerprint().Return("testfp1").Times(2)
-				b.EXPECT().BlockInProgress("testfp1").Return(true, nil)
+				t.EXPECT().ExecutorName().Return("shell").Times(2)
+				b.EXPECT().BlockInProgress("shell", "testfp1").Return(true, nil)
 				t.EXPECT().Exec(l).Return(nil)
-				b.EXPECT().BlockForTTL("testfp1", 10*time.Minute).Return(errors.New("some block error"))
+				b.EXPECT().BlockForTTL("shell", "testfp1", 10*time.Minute).Return(errors.New("some block error"))
 			},
 			expectedResult: execResultCanNotBlock,
 			expectedErr:    errors.New("some block error"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -66,9 +66,9 @@ func runner(tasksCh chan model.Tasks, blocker blocker, metric metricser, logger 
 //go:generate mockgen -source=runner.go -destination=runner_mocks.go -package=runner doc github.com/golang/mock/gomock
 
 type blocker interface {
-	BlockInProgress(fingerprint string) (blockedSuccessfully bool, err error)
-	BlockForTTL(fingerprint string, ttl time.Duration) (err error)
-	Unblock(fingerprint string)
+	BlockInProgress(executor, fingerprint string) (blockedSuccessfully bool, err error)
+	BlockForTTL(executor, fingerprint string, ttl time.Duration) (err error)
+	Unblock(executor, fingerprint string)
 }
 
 type metricser interface {

--- a/runner/runner_mocks.go
+++ b/runner/runner_mocks.go
@@ -34,38 +34,38 @@ func (m *Mockblocker) EXPECT() *MockblockerMockRecorder {
 }
 
 // BlockInProgress mocks base method
-func (m *Mockblocker) BlockInProgress(fingerprint string) (bool, error) {
-	ret := m.ctrl.Call(m, "BlockInProgress", fingerprint)
+func (m *Mockblocker) BlockInProgress(executor, fingerprint string) (bool, error) {
+	ret := m.ctrl.Call(m, "BlockInProgress", executor, fingerprint)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockInProgress indicates an expected call of BlockInProgress
-func (mr *MockblockerMockRecorder) BlockInProgress(fingerprint interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockInProgress", reflect.TypeOf((*Mockblocker)(nil).BlockInProgress), fingerprint)
+func (mr *MockblockerMockRecorder) BlockInProgress(executor, fingerprint interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockInProgress", reflect.TypeOf((*Mockblocker)(nil).BlockInProgress), executor, fingerprint)
 }
 
 // BlockForTTL mocks base method
-func (m *Mockblocker) BlockForTTL(fingerprint string, ttl time.Duration) error {
-	ret := m.ctrl.Call(m, "BlockForTTL", fingerprint, ttl)
+func (m *Mockblocker) BlockForTTL(executor, fingerprint string, ttl time.Duration) error {
+	ret := m.ctrl.Call(m, "BlockForTTL", executor, fingerprint, ttl)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BlockForTTL indicates an expected call of BlockForTTL
-func (mr *MockblockerMockRecorder) BlockForTTL(fingerprint, ttl interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockForTTL", reflect.TypeOf((*Mockblocker)(nil).BlockForTTL), fingerprint, ttl)
+func (mr *MockblockerMockRecorder) BlockForTTL(executor, fingerprint, ttl interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockForTTL", reflect.TypeOf((*Mockblocker)(nil).BlockForTTL), executor, fingerprint, ttl)
 }
 
 // Unblock mocks base method
-func (m *Mockblocker) Unblock(fingerprint string) {
-	m.ctrl.Call(m, "Unblock", fingerprint)
+func (m *Mockblocker) Unblock(executor, fingerprint string) {
+	m.ctrl.Call(m, "Unblock", executor, fingerprint)
 }
 
 // Unblock indicates an expected call of Unblock
-func (mr *MockblockerMockRecorder) Unblock(fingerprint interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unblock", reflect.TypeOf((*Mockblocker)(nil).Unblock), fingerprint)
+func (mr *MockblockerMockRecorder) Unblock(executor, fingerprint interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unblock", reflect.TypeOf((*Mockblocker)(nil).Unblock), executor, fingerprint)
 }
 
 // Mockmetricser is a mock of metricser interface

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -63,11 +63,11 @@ func TestStart(t *testing.T) {
 						for _, t := range ts {
 							t.EXPECT().BlockTTL().Return(10 * time.Minute)
 							t.EXPECT().Fingerprint().Return("testfp2")
-							b.EXPECT().BlockInProgress("testfp2").Return(false, nil)
+							t.EXPECT().ExecutorName().Return("shell").Times(4)
+							b.EXPECT().BlockInProgress("shell", "testfp2").Return(false, nil)
 							t.EXPECT().EventID().Return("testid2").Times(2)
 							t.EXPECT().Rule().Return("testrule2").Times(3)
 							t.EXPECT().Alert().Return("testalert2").Times(3)
-							t.EXPECT().ExecutorName().Return("shell").Times(3)
 							t.EXPECT().ExecutorDetails().Return("testtask2").Times(2)
 							m.EXPECT().ExecutedTaskObserve("testrule2", "testalert2", "shell", execResultInBlock.String(), nil, 0*time.Second)
 						}
@@ -79,13 +79,13 @@ func TestStart(t *testing.T) {
 						for _, t := range ts {
 							t.EXPECT().BlockTTL().Return(10 * time.Minute).Times(2)
 							t.EXPECT().Fingerprint().Return("testfp3").Times(2)
-							b.EXPECT().BlockInProgress("testfp3").Return(true, nil)
+							t.EXPECT().ExecutorName().Return("shell").Times(5)
+							b.EXPECT().BlockInProgress("shell", "testfp3").Return(true, nil)
 							t.EXPECT().Exec(l).Return(nil)
-							b.EXPECT().BlockForTTL("testfp3", 10*time.Minute).Return(nil)
+							b.EXPECT().BlockForTTL("shell", "testfp3", 10*time.Minute).Return(nil)
 							t.EXPECT().EventID().Return("testid3").Times(2)
 							t.EXPECT().Rule().Return("testrule3").Times(3)
 							t.EXPECT().Alert().Return("testalert3").Times(3)
-							t.EXPECT().ExecutorName().Return("shell").Times(3)
 							t.EXPECT().ExecutorDetails().Return("testtask3").Times(2)
 							m.EXPECT().ExecutedTaskObserve("testrule3", "testalert3", "shell", execResultSuccess.String(), nil, 0*time.Second)
 						}
@@ -107,13 +107,13 @@ func TestStart(t *testing.T) {
 
 							t.EXPECT().BlockTTL().Return(10 * time.Minute)
 							t.EXPECT().Fingerprint().Return("testfp4").Times(2)
-							b.EXPECT().BlockInProgress("testfp4").Return(true, nil)
+							t.EXPECT().ExecutorName().Return("shell").Times(5)
+							b.EXPECT().BlockInProgress("shell", "testfp4").Return(true, nil)
 							t.EXPECT().Exec(l).Return(errors.New("exec error"))
-							b.EXPECT().Unblock("testfp4")
+							b.EXPECT().Unblock("shell", "testfp4")
 							t.EXPECT().EventID().Return("testid4").Times(2)
 							t.EXPECT().Rule().Return("testrule4").Times(3)
 							t.EXPECT().Alert().Return("testalert4").Times(3)
-							t.EXPECT().ExecutorName().Return("shell").Times(3)
 							t.EXPECT().ExecutorDetails().Return("testtask4").Times(2)
 							m.EXPECT().ExecutedTaskObserve("testrule4", "testalert4", "shell", execResultExecError.String(), errors.New("exec error"), 0*time.Second)
 						}
@@ -137,15 +137,17 @@ func TestStart(t *testing.T) {
 							if i == 0 {
 								t.EXPECT().BlockTTL().Return(10 * time.Minute).Times(2)
 								t.EXPECT().Fingerprint().Return(fmt.Sprintf("testfp%v", i+shift)).Times(2)
-								b.EXPECT().BlockInProgress(fmt.Sprintf("testfp%v", i+shift)).Return(true, nil)
+								t.EXPECT().ExecutorName().Return("shell").Times(2)
+								b.EXPECT().BlockInProgress("shell", fmt.Sprintf("testfp%v", i+shift)).Return(true, nil)
 								t.EXPECT().Exec(l).Return(nil)
 								result = execResultSuccess
-								b.EXPECT().BlockForTTL(fmt.Sprintf("testfp%v", i+shift), 10*time.Minute).Return(nil)
+								b.EXPECT().BlockForTTL("shell", fmt.Sprintf("testfp%v", i+shift), 10*time.Minute).Return(nil)
 							}
 							if i == 1 {
 								t.EXPECT().BlockTTL().Return(10 * time.Minute).Times(1)
 								t.EXPECT().Fingerprint().Return(fmt.Sprintf("testfp%v", i+shift))
-								b.EXPECT().BlockInProgress(fmt.Sprintf("testfp%v", i+shift)).Return(false, nil)
+								t.EXPECT().ExecutorName().Return("shell")
+								b.EXPECT().BlockInProgress("shell", fmt.Sprintf("testfp%v", i+shift)).Return(false, nil)
 								result = execResultInBlock
 							}
 							t.EXPECT().EventID().Return(fmt.Sprintf("testid%v", i+shift)).Times(2)


### PR DESCRIPTION
Executor added to block key as a protection for blocking same fingerprints from different executors