### PR TITLE
Add curl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ RUN \
 
 FROM alpine:3.8
 COPY --from=builder /go/src/github.com/krpn/prometheus-alert-webhooker/cmd/prometheus-alert-webhooker/prometheus-alert-webhooker /
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata curl
 EXPOSE 8080
 ENTRYPOINT ["/prometheus-alert-webhooker"]


### PR DESCRIPTION
Curl allows for http POST which is an efficient way to integrate with APIs in other systems.
Also, having curl allows using the Jenkins API directly which would make the Jenkins section unnecessary (less maintenance).